### PR TITLE
AS event diagram fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: psichomics
 Title: Graphical Interface for Alternative Splicing Quantification, Analysis and
     Visualisation
-Version: 1.18.4
+Version: 1.18.5
 Encoding: UTF-8
 Authors@R: c(
         person("Nuno", "Saraiva-Agostinho",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# psichomics 1.18.5 (23 August, 2021)
+
+* Diagrams of alternative splicing events:
+    - Fix wrong coloring of reference exon used for AFE and A5SS events
+* Transcript plot:
+    - Orange region (the reference exon) is now on top of blue region
+    - Fix loading twice when selecting a new event (visual interface)
+
 # psichomics 1.18.4 (22 July, 2021)
 
 * `psichomics()`: fix visual interface not launching

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-# psichomics 1.18.5 (23 August, 2021)
+# psichomics 1.18.5 (24 August, 2021)
 
 * Diagrams of alternative splicing events:
     - Fix wrong coloring of reference exon used for AFE and A5SS events
 * Transcript plot:
-    - Orange region (the reference exon) is now on top of blue region
+    - Avoid alternative regions from overlapping
     - Fix loading twice when selecting a new event (visual interface)
 
 # psichomics 1.18.4 (22 July, 2021)

--- a/R/analysis_information.R
+++ b/R/analysis_information.R
@@ -473,8 +473,8 @@ plotASeventRegion <- function(hc, event, data=NULL) {
         text <- paste(pretty, "(alternative region in orange)")
     }
 
-    orange <- "#ffb15380"
-    blue   <- "#7db6ec80"
+    orange <- "#ffb153cc"
+    blue   <- "#7db6eccc"
     grey   <- "#d3d3d388"
     orangeBand <- blueBand <- greyBand <- NULL
 
@@ -500,16 +500,16 @@ plotASeventRegion <- function(hc, event, data=NULL) {
         upstreamPlus    <- type %in% c("A5SS", "AFE") && plusStrand
         upstreamMinus   <- type %in% c("A5SS", "AFE") && !plusStrand
 
+        shiftBy <- min(abs(alt1 - alt2), 200)
         if (downstreamPlus || upstreamMinus) {
             gradient   <- "normal"
-            orangePos <- c(alt1, shift(alt1, `+`))
-            bluePos   <- c(alt2, shift(alt2, `+`))
+            orangePos <- c(alt1, shift(alt1, `+`, by=shiftBy))
+            bluePos   <- c(alt2, shift(alt2, `+`, by=shiftBy))
         } else if (upstreamPlus || downstreamMinus) {
             gradient   <- "invert"
-            orangePos <- c(shift(alt1, `-`), alt1)
-            bluePos   <- c(shift(alt2, `-`), alt2)
+            orangePos <- c(shift(alt1, `-`, by=shiftBy), alt1)
+            bluePos   <- c(shift(alt2, `-`, by=shiftBy), alt2)
         }
-
         greyBand   <- plotBand(grey, greyPos[[1]], greyPos[[2]], text=text)
         orangeBand <- plotBand(orange, orangePos[[1]], orangePos[[2]], gradient)
         blueBand   <- plotBand(blue, bluePos[[1]], bluePos[[2]], gradient)

--- a/R/analysis_information.R
+++ b/R/analysis_information.R
@@ -23,9 +23,9 @@
 #' psichomics:::queryEnsembl(path, query, grch37 = TRUE)
 queryEnsembl <- function(path, query, grch37 = TRUE) {
     url <- paste0("http://", if(grch37) "grch37.", "rest.ensembl.org")
-    resp <- tryCatch(GET(url, path=path, query=query, config=timeout(10)), 
+    resp <- tryCatch(GET(url, path=path, query=query, config=timeout(10)),
                      error=return)
-    
+
     if (is(resp, "error") || http_error(resp) || is.null(resp)) # Time out
         return(NULL) # for instance, time out
     r <- content(resp, "text", encoding = "UTF8")
@@ -33,18 +33,18 @@ queryEnsembl <- function(path, query, grch37 = TRUE) {
 }
 
 #' Query information from Ensembl
-#' 
+#'
 #' @param gene Character: gene
-#' @param species Character: species (may be \code{NULL} for an Ensembl 
+#' @param species Character: species (may be \code{NULL} for an Ensembl
 #' identifier)
-#' @param assembly Character: assembly version (may be NULL for an Ensembl 
+#' @param assembly Character: assembly version (may be NULL for an Ensembl
 #' identifier)
-#' 
+#'
 #' @family functions to retrieve external information
 #' @return Information from Ensembl
 #' @export
-#' 
-#' @examples 
+#'
+#' @examples
 #' queryEnsemblByGene("BRCA1", "human", "hg19")
 #' queryEnsemblByGene("ENSG00000139618")
 queryEnsemblByGene <- function(gene, species=NULL, assembly=NULL) {
@@ -62,12 +62,12 @@ queryEnsemblByGene <- function(gene, species=NULL, assembly=NULL) {
 }
 
 #' @rdname queryEnsemblByGene
-#' 
+#'
 #' @param event Character: alternative splicing event
 #' @inheritParams parseSplicingEvent
-#' 
+#'
 #' @export
-#' @examples 
+#' @examples
 #' event <- "SE_17_-_41251792_41249306_41249261_41246877_BRCA1"
 #' queryEnsemblByEvent(event, species="human", assembly="hg19")
 queryEnsemblByEvent <- function(event, species=NULL, assembly=NULL, data=NULL) {
@@ -88,12 +88,12 @@ queryEnsemblByEvent <- function(event, species=NULL, assembly=NULL, data=NULL) {
 #'
 #' @return Parsed response
 #' @keywords internal
-#' 
+#'
 #' @examples
 #' protein <- "P51587"
 #' format <- "xml"
 #' psichomics:::queryUniprot(protein, format)
-#' 
+#'
 #' transcript <- "ENST00000488540"
 #' format <- "xml"
 #' psichomics:::queryUniprot(transcript, format)
@@ -107,7 +107,7 @@ queryUniprot <- function(molecule, format="xml") {
 }
 
 #' Query the PubMed REST API
-#' 
+#'
 #' @param primary Character: primary search term
 #' @param ... Character: other relevant search terms
 #' @param top Numeric: number of articles to retrieve
@@ -115,7 +115,7 @@ queryUniprot <- function(molecule, format="xml") {
 #' (\code{abstract} by default)
 #' @param sort Character: sort by a given parameter (\code{relevance} by
 #' default)
-#' 
+#'
 #' @importFrom httr GET
 #' @importFrom jsonlite fromJSON
 #'
@@ -124,7 +124,7 @@ queryUniprot <- function(molecule, format="xml") {
 #'
 #' @examples
 #' psichomics:::queryPubMed("BRCA1", "cancer", "adrenocortical carcinoma")
-queryPubMed <- function(primary, ..., top=3, field="abstract", 
+queryPubMed <- function(primary, ..., top=3, field="abstract",
                         sort="relevance") {
     args  <- unlist(list(...))
     if (!is.null(args)) {
@@ -133,14 +133,14 @@ queryPubMed <- function(primary, ..., top=3, field="abstract",
         terms <- primary
     }
     url <- "https://eutils.ncbi.nlm.nih.gov"
-    query <- list(db="pubmed", term=terms, retmax=top, tool="psichomics", 
+    query <- list(db="pubmed", term=terms, retmax=top, tool="psichomics",
                   field=field, sort=sort,
                   email="nunodanielagostinho@gmail.com", retmode="json")
     resp <- GET(url, path="entrez/eutils/esearch.fcgi", query=query)
     warn_for_status(resp)
     search <- content(resp, "text", encoding = "UTF8")
     search <- fromJSON(search)[[2]]
-    
+
     # Get summary information on the articles
     ids <- paste(search$idlist, collapse="+")
     query <- list(db="pubmed", tool="psichomics", id=ids,
@@ -153,28 +153,28 @@ queryPubMed <- function(primary, ..., top=3, field="abstract",
 }
 
 #' Convert from Ensembl to UniProt identifier
-#' 
+#'
 #' @param protein Character: Ensembl identifier
-#' 
+#'
 #' @family functions to retrieve external information
 #' @return UniProt protein identifier
 #' @export
-#' 
-#' @examples 
+#'
+#' @examples
 #' gene <- "ENSG00000173262"
 #' ensemblToUniprot(gene)
-#' 
+#'
 #' protein <- "ENSP00000445929"
 #' ensemblToUniprot(protein)
 ensemblToUniprot <- function(protein) {
     if(length(protein) != 1) stop("Only pass one Ensembl identifier")
-    
+
     external <- queryEnsembl(paste0("xrefs/id/", protein),
                              list("content-type"="application/json"),
                              grch37=TRUE)
-    
+
     if (is.null(external)) return(NULL)
-        
+
     db <- external[grepl("Uniprot", external$dbname), ]
     uniprot <- db$primary_id
     names(uniprot) <- sprintf("%s (%s)", db$display_id, db$db_display_name)
@@ -182,28 +182,28 @@ ensemblToUniprot <- function(protein) {
 }
 
 #' Return the interface of relevant PubMed articles for a given gene
-#' 
+#'
 #' @param ns Namespace function
 #' @param gene Character: gene
 #' @inheritDotParams queryPubMed -primary
-#' 
+#'
 #' @return HTML interface of relevant PubMed articles
 #' @keywords internal
 pubmedUI <- function(ns, gene, ...) {
     terms <- unlist(as.list(...))
     if (!is.null(gene)) gene <- setNames("gene", gene)
     terms <- c(gene, setNames(terms, terms))
-    
+
     selectTerms <- selectizeInput(
         ns("articleTerms"), label=NULL, choices=terms, selected=terms,
         multiple=TRUE, width="auto", options=list(
             create=TRUE, createOnBlur=TRUE, persist=TRUE,
             plugins=list('remove_button'), placeholder="Add keywords..."))
     selectTerms[[2]]$style <- paste(selectTerms[[2]]$style, "margin-bottom: 0;")
-    
-    div(class="panel panel-default", 
-        div(class="panel-heading", 
-            tags$b("Relevant PubMed articles", 
+
+    div(class="panel panel-default",
+        div(class="panel-heading",
+            tags$b("Relevant PubMed articles",
                    uiOutput(ns("articleSearch"), inline=TRUE))),
         div(class="list-group", tags$li(class="list-group-item", selectTerms),
             uiOutput(ns("articleList"))))
@@ -214,7 +214,7 @@ pubmedUI <- function(ns, gene, ...) {
 #' @importFrom R.utils capitalize
 infoUI <- function(id) {
     ns <- NS(id)
-    
+
     renderSelectize <- function(option_create) {
         render <- sprintf(
             "{ option_create: function (data, escape) {
@@ -222,7 +222,7 @@ infoUI <- function(id) {
             option_create)
         return(I(render))
     }
-    
+
     species <- c(paste("human", c("hg19", "hg38")),
                  paste("mouse", c("mm9", "mm10")),
                  "rat rn6",
@@ -232,7 +232,7 @@ infoUI <- function(id) {
                  "Saccharomyces_cerevisiae sacCer3")
     #setNames(paste(names(species), species),
     #         capitalize(sprintf("%s (%s assembly)", names(species), species)))
-    
+
     onFocus <- I('function() { this.clear(); }')
     renderSpecies <- renderSelectize(
         option_create=paste(
@@ -244,7 +244,7 @@ infoUI <- function(id) {
         choices=species, selected=species[[1]],
         options=list(placeholder="Search for a species...", highlight=FALSE,
                      create=TRUE, onFocus=onFocus, render=renderSpecies))
-    
+
     renderGene <- renderSelectize(
         option_create=paste(
             "'Search for <strong>' + escape(data.input) + '</strong>&hellip;'"))
@@ -270,7 +270,7 @@ infoUI <- function(id) {
 parseUniprotXML <- function(xml) {
     doc <- xmlTreeParse(xml)
     root <- xmlRoot(doc)[[1]]
-    
+
     # Extract protein name, length, function and features
     names         <- vapply(xmlChildren(root), xmlName, character(1))
     comments      <- root[names == "comment"]
@@ -283,17 +283,17 @@ parseUniprotXML <- function(xml) {
     proteinName   <- tryCatch(
         toString(root[names == "protein"][[1]][[1]][[1]][[1]]),
         error=function(cond) NULL)
-    
+
     # Convert list of XMLNodes to list of characters
     l <- lapply(featureNodes, function(feat) {
         attrs <- xmlAttrs(feat)
-        
+
         location  <- feat[[match("location", names(feat))]]
         start <- as.numeric(xmlAttrs(location[[1]]))
         # If there's no stop position, simply sum 1 to the start position
         stop  <- tryCatch(as.numeric(xmlAttrs(location[[2]])),
                           error=function(e) start+1)
-        
+
         # Get original and variant aminoacid
         variant <- match("variation", names(feat))
         if (!is.na(variant) && !is.null(variant)) {
@@ -305,7 +305,7 @@ parseUniprotXML <- function(xml) {
         }
         return(c(attrs, start=start, stop=stop, variant=variant))
     })
-    
+
     # Convert list of characters to data frame of characters
     feature <- ldply(l, rbind)
     if (ncol(feature) > 0) {
@@ -315,7 +315,7 @@ parseUniprotXML <- function(xml) {
         feature$start <- as.numeric(feature$start)
         feature$stop <- as.numeric(feature$stop)
     }
-    
+
     return(list(name=proteinName, length=length, role=role, feature=feature))
 }
 
@@ -332,7 +332,7 @@ parseUniprotXML <- function(xml) {
 #' @examples
 #' protein <- "P38398"
 #' plotProtein(protein)
-#' 
+#'
 #' transcript <- "ENST00000488540"
 #' plotProtein(transcript)
 plotProtein <- function(molecule) {
@@ -343,7 +343,7 @@ plotProtein <- function(molecule) {
     length  <- parsed$length
     role    <- parsed$role
     feature <- parsed$feature
-    
+
     hc <- highchart() %>%
         hc_chart(type="area", zoomType="x") %>%
         hc_xAxis(title=list(text="Position (aminoacids)"), min=0,
@@ -352,30 +352,30 @@ plotProtein <- function(molecule) {
         hc_tooltip(pointFormat="<b>{series.name} {point.id}</b>
                    <br>{point.variant}{point.description}") %>%
         export_highcharts()
-    
+
     # The diverse types of features available
     types <- unique(feature$type)
-    
+
     featureList <- NULL
     if (nrow(feature) == 0) {
         stop("No annotated domains were found for this protein in UniProt")
     }
-    
+
     # Reverse elements from features so the first ones (smaller Y) are above
     for (feat in nrow(feature):1) {
         feat <- feature[feat, ]
-        
+
         # If there's no stop position, simply sum 1 to the start position
         stop <- ifelse(!is.na(feat$stop), feat$stop, feat$start + 1)
         y <- match(feat$type, types)
-        
+
         # Create a list with two points based on this region
         temp <- list(NULL,
                      list(x=feat$start, y=y, description=feat$description,
                           id=feat$id, variant=feat$variant),
                      list(x=feat$stop,  y=y, description=feat$description,
                           id=feat$id, variant=feat$variant))
-        
+
         # Either make a new list or append to existing
         if (is.null(featureList[feat$type])) {
             featureList[[feat$type]] <- temp[2:3]
@@ -385,28 +385,28 @@ plotProtein <- function(molecule) {
     }
     for (type in names(featureList))
         hc <- hc %>% hc_add_series(name=type, data=featureList[[type]])
-    
+
     attr(hc, "protein") <- parsed
     return(hc)
 }
 
 #' HTML code to plot a X-ranges series
-#' 
+#'
 #' @param hc \code{highcharter} object
 #' @inheritParams plotTranscripts
-#' 
+#'
 #' @importFrom shiny tagList tags includeScript div
 #' @importFrom htmltools browsable
 #' @importFrom jsonlite toJSON
-#' 
+#'
 #' @return HTML elements
 #' @keywords internal
 plottableXranges <- function(hc, shiny=FALSE) {
     hc <- toJSON(hc$x$hc_opts, auto_unbox=TRUE)
     hc <- gsub('"---|---"', "", hc)
-    
+
     extended <- includeScript(insideFile("shiny", "www", "highcharts.ext.js"))
-    
+
     if (shiny) {
         # No need to load Highcharts in Shiny
         container <- tagList(extended, div(id="container"))
@@ -416,69 +416,68 @@ plottableXranges <- function(hc, shiny=FALSE) {
             tags$script(src="https://code.highcharts.com/modules/exporting.js"),
             extended, div(id="container", style="height: 100vh;"))
     }
-    
+
     browsable(tagList(
-        container, 
+        container,
         tags$script(sprintf("Highcharts.chart('container', %s)", hc))))
+}
+
+plotBand <- function(colour, from, to, gradient=NULL, text=NULL) {
+    coords <- sort(c(from, to))
+    from   <- coords[[1]]
+    to     <- coords[[2]]
+
+    if (!is.null(text))
+        label <- list(text=text, y=10, style=list(fontWeight="bold"))
+    else
+        label <- list(y=10)
+
+    if (is.null(gradient)) {
+        res <- list(color=colour, from=from, to=to, label=label)
+    } else {
+        noColour <- "rgba(255, 255, 255, 0)"
+        if (gradient == "invert") {
+            firstColour <- colour
+            lastColour  <- noColour
+        } else {
+            firstColour <- noColour
+            lastColour  <- colour
+        }
+
+        res <- list(
+            color=list(
+                linearGradient=list(x1=1, x2=0, y1=1, y2=1),
+                stops=list(c(0, firstColour), c(1, lastColour))),
+            from=from, to=to, label=label)
+    }
+    return(res)
 }
 
 plotASeventRegion <- function(hc, event, data=NULL) {
     parsed <- parseSplicingEvent(event, coords=TRUE, data=data)[1, , drop=FALSE]
     if (is.null(parsed)) return(NULL)
-    
+
     con1 <- sort(parsed$constitutive1[[1]])
     alt1 <- sort(parsed$alternative1[[1]])
     alt2 <- sort(parsed$alternative2[[1]])
     con2 <- sort(parsed$constitutive2[[1]])
     if (length(c(con1, alt1, alt2, con2)) == 0) return(NULL)
     type <- parsed$type
-    
+
     if (type %in% c("AFE exon", "ALE exon")) type <- gsub(" exon", "", type)
     pretty <- prettifyEventType(type)
-    
+
     if (type %in% c("MXE", "A3SS", "A5SS", "AFE", "ALE")) {
         text <- paste(pretty, "(alternative regions in orange and blue)")
     } else if (type %in% c("SE")) {
         text <- paste(pretty, "(alternative region in orange)")
     }
-    
-    orange <- "rgba(250, 165,  47, 0.5)"
-    blue   <- "rgba(124, 181, 236, 0.5)"
-    grey   <- "#D3D3D388"
-    plotBand <- function(colour, from, to, gradient=NULL, text=NULL) {
-        coords <- sort(c(from, to))
-        from   <- coords[[1]]
-        to     <- coords[[2]]
-        
-        if (!is.null(text))
-            label <- list(text=text, y=10, style=list(fontWeight="bold"))
-        else
-            label <- list(y=10)
-        
-        if (is.null(gradient)) {
-            list(color=colour, from=from, to=to, label=label)
-        } else {
-            noColour <- "rgba(255, 255, 255, 0)"
-            if (gradient == "invert") {
-                firstColour <- colour
-                lastColour  <- noColour
-            } else {
-                firstColour <- noColour
-                lastColour  <- colour
-            }
-            
-            list(
-                color=list(
-                    linearGradient=list(x1=1, x2=0, y1=1, y2=1),
-                    stops=list(c(0, firstColour), c(1, lastColour))),
-                from=from, to=to, label=label)
-        }
-    }
-    
-    orangeBand <- NULL
-    blueBand   <- NULL
-    greyBand   <- NULL
-    
+
+    orange <- "#ffb15380"
+    blue   <- "#7db6ec80"
+    grey   <- "#d3d3d388"
+    orangeBand <- blueBand <- greyBand <- NULL
+
     if (type == "SE") {
         orangeBand <- plotBand(orange, alt1[[1]], alt1[[2]])
         greyBand   <- plotBand(grey,   con1,      con2, text=text)
@@ -489,18 +488,18 @@ plotASeventRegion <- function(hc, event, data=NULL) {
     } else if (type %in% c("A3SS", "A5SS", "AFE", "ALE")) {
         # Shift a given position
         shift <- function(pos, FUN, by=200) { FUN(as.numeric(pos), by) }
-        
+
         if (type == "A3SS")      greyPos <- range(con1, alt1, alt2)
         else if (type == "A5SS") greyPos <- range(alt1, alt2, con2)
         else if (type == "AFE")  greyPos <- range(alt1, alt2, con2)
         else if (type == "ALE")  greyPos <- range(con1, alt1, alt2)
-        
-        plusStrand <- parsed$strand == "+"
+
+        plusStrand      <- parsed$strand == "+"
         downstreamMinus <- type %in% c("A3SS", "ALE") && !plusStrand
         downstreamPlus  <- type %in% c("A3SS", "ALE") && plusStrand
         upstreamPlus    <- type %in% c("A5SS", "AFE") && plusStrand
         upstreamMinus   <- type %in% c("A5SS", "AFE") && !plusStrand
-        
+
         if (downstreamPlus || upstreamMinus) {
             gradient   <- "normal"
             orangePos <- c(alt1, shift(alt1, `+`))
@@ -510,32 +509,32 @@ plotASeventRegion <- function(hc, event, data=NULL) {
             orangePos <- c(shift(alt1, `-`), alt1)
             bluePos   <- c(shift(alt2, `-`), alt2)
         }
-        
+
         greyBand   <- plotBand(grey, greyPos[[1]], greyPos[[2]], text=text)
         orangeBand <- plotBand(orange, orangePos[[1]], orangePos[[2]], gradient)
         blueBand   <- plotBand(blue, bluePos[[1]], bluePos[[2]], gradient)
     }
-    
-    hc <- hc_xAxis(hc, plotBands=list(greyBand, orangeBand, blueBand))
+    # Ordered by stack order starting with the gray as background
+    hc <- hc_xAxis(hc, plotBands=list(greyBand, blueBand, orangeBand))
     return(hc)
 }
 
 #' Plot transcripts
-#' 
+#'
 #' @param info Information retrieved from Ensembl
 #' @param eventPosition Numeric: coordinates of the alternative splicing event
 #' (ignored if \code{event} is set)
 #' @param event Character: identifier of the alternative splicing event to plot
 #' @param eventData Object containing event information to be parsed
 #' @param shiny Boolean: is the function running in a Shiny session?
-#' 
+#'
 #' @importFrom highcharter highchart hc_chart hc_title hc_legend hc_xAxis
 #' hc_yAxis hc_plotOptions hc_tooltip hc_series
-#' 
+#'
 #' @family functions to retrieve external information
 #' @inherit psichomics return
 #' @export
-#' 
+#'
 #' @examples
 #' event <- "SE_12_-_7985318_7984360_7984200_7982602_SLC2A14"
 #' info  <- queryEnsemblByEvent(event, species="human", assembly="hg19")
@@ -554,7 +553,7 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
         start   <- transcript$start
         end     <- transcript$end
         biotype <- gsub("_", " ", transcript$biotype)
-        
+
         # Prepare exons
         elements <- list()
         exons <- transcript$Exon[[1]]
@@ -566,7 +565,7 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
             elements <- c(elements, list(list(
                 name="exon", x=start, x2=end, y=0, width=20, length=len)))
         }
-        
+
         if (nrow(exons) > 1) {
             # Prepare introns
             introns <- NULL
@@ -584,7 +583,7 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
                                   display=display, strand=strand, chr=chr,
                                   biotype=biotype, data=elements)))
     }
-    
+
     # Plot transcripts
     hc <- highchart() %>%
         hc_chart(type="xrange", zoomType="x") %>%
@@ -596,7 +595,7 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
         hc_plotOptions(series=list(borderWidth=0.5)) %>%
         hc_tooltip(followPointer=TRUE)
     hc <- do.call("hc_series", c(list(hc), data))
-    
+
     if (!is.null(event)) {
         plotRegion <- plotASeventRegion(hc, event, eventData)
         if (!is.null(plotRegion)) hc <- plotRegion
@@ -605,11 +604,11 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
         eventStart <- eventPosition[1]
         eventEnd   <- eventPosition[2]
         hc <- hc_xAxis(hc, plotBands=list(
-            color="#7cb5ec50", from=eventStart, 
+            color="#7cb5ec50", from=eventStart,
             to=eventEnd, label=list(text="Splicing Event", y=10,
                                     style=list(fontWeight="bold"))))
     }
-    
+
     if (shiny)
         hc <- hc %>% hc_plotOptions(series=list(cursor="pointer", events=list(
             click="---function(e) { setTranscript(this.name); }---")))
@@ -617,7 +616,7 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
 }
 
 #' Render genetic information
-#' 
+#'
 #' @param output Shiny output
 #' @param ns Namespace function
 #' @param info Information as retrieved from Ensembl
@@ -625,28 +624,28 @@ plotTranscripts <- function(info, eventPosition=NULL, event=NULL,
 #' @param assembly Character: assembly version
 #' @param grch37 Boolean: use version GRCh37 of the genome?
 #' @param eventDiagram Diagram of selected alternative splicing event
-#' 
+#'
 #' @importFrom shiny renderUI h2 h3 plotOutput
-#' 
+#'
 #' @return HTML elements to render gene, protein and transcript annotation
 #' @keywords internal
-renderGeneticInfo <- function(output, info, species=NULL, assembly=NULL, 
+renderGeneticInfo <- function(output, info, species=NULL, assembly=NULL,
                               grch37=FALSE, eventDiagram=NULL, gene=NULL) {
     start <- as.numeric(info$start)
     end   <- as.numeric(info$end)
-    
-    item <- function(dt, dd, dtWidth="width: 80px;", 
+
+    item <- function(dt, dd, dtWidth="width: 80px;",
                      ddMargin="margin-left: 100px;",
                      ddStyle=NULL) {
         tagList(tags$dt(style=dtWidth, dt),
                 tags$dd(style=ddMargin, style=ddStyle, dd))
     }
-    
+
     unavailableItem <- function(dt, dd, ...) {
         info <- tagList(icon("times-circle"), dd)
         return(item(dt, info, ddStyle="color: gray;"))
     }
-    
+
     if (is.null(info)) {
         msg <- "Information from Ensembl currently unavailable"
         genomicLocation <- unavailableItem("Location", msg)
@@ -659,11 +658,11 @@ renderGeneticInfo <- function(output, info, species=NULL, assembly=NULL,
                 format(start, big.mark=",", scientific=FALSE),
                 format(end, big.mark=",", scientific=FALSE),
                 ifelse(info$strand == -1, "reverse", "forward")))
-        description <- item("Description", 
+        description <- item("Description",
                             sprintf("%s (%s)", info$description, info$biotype))
     }
     links <- prepareExternalLinks(info, species, assembly, grch37, gene)
-    
+
     tagList(
         h2(style="margin-top: 0px;", info$display_name, tags$small(info$id)),
         tags$dl(class="dl-horizontal", style="margin-bottom: 0px;",
@@ -675,11 +674,11 @@ renderGeneticInfo <- function(output, info, species=NULL, assembly=NULL,
 }
 
 #' Return the interface to display an article
-#' 
+#'
 #' @param article PubMed article
-#' 
+#'
 #' @importFrom shiny tags h5
-#' 
+#'
 #' @return HTML to render an article's interface
 #' @keywords internal
 articleUI <- function(article) {
@@ -691,34 +690,34 @@ articleUI <- function(article) {
     }
     year <- strsplit(article$pubdate, " ")[[1]][[1]]
     description <- sprintf("%s (%s)", authors, year)
-    
+
     source <- article$source
     if (source != "") description <- sprintf("%s. %s", description, source)
-    
+
     volume <- article$volume
     issue <- article$issue
     if (volume != "" && issue != "")
         description <- sprintf("%s, %s(%s)", description, volume, issue)
     else if (volume != "")
         description <- sprintf("%s, %s", description, volume)
-    
+
     description <- sprintf("%s.", description)
     pmid <- article$articleids$value[1]
-    
+
     decodeHTMLentities <- function(char) {
         char <- gsub("&lt;", "<", char, fixed=TRUE)
         char <- gsub("&gt;", ">", char, fixed=TRUE)
         return(HTML(char))
     }
-    
+
     tags$a(href=paste0("http://pubmed.gov/", pmid), target="_blank",
-           class="list-group-item", h5(class="list-group-item-heading", 
+           class="list-group-item", h5(class="list-group-item-heading",
                                        decodeHTMLentities(article$title),
                                        tags$small(description)))
 }
 
 #' Render protein information
-#' 
+#'
 #' @param protein Character: protein identifier
 #' @param transcript Character: Ensembl identifier of the protein's respective
 #' transcript
@@ -733,7 +732,7 @@ renderProteinInfo <- function(protein, transcript, species, assembly) {
         name <- sprintf("%s (%s aminoacids)", protein$name, protein$length)
         name <- column(2, tags$label("Protein name"), tags$ul(
             class="list-inline", tags$li(style="padding-top: 7px;", name)))
-        
+
         # Prepare protein role
         if (is.null(protein$role) || protein$role == "")
             role <- helpText("No annotated function", style="margin: 0;")
@@ -743,18 +742,18 @@ renderProteinInfo <- function(protein, transcript, species, assembly) {
                        tags$ul(class="list-inline",
                                tags$li(style="padding-top: 7px;", role)))
     }
-    
+
     # Prepare external links
     grch37      <- if (assembly == "hg19") "grch37." else ""
-    href        <- sprintf("http://%sensembl.org/%s/Transcript/Summary?t=%s", 
+    href        <- sprintf("http://%sensembl.org/%s/Transcript/Summary?t=%s",
                            grch37, species, transcript)
     ensemblLink <- tags$a("Ensembl", icon("external-link"), href=href,
                           target="_blank")
-    
+
     href        <- paste0("http://www.uniprot.org/uniprot/?query=", transcript)
     uniprotLink <- tags$a("UniProt", icon("external-link"), href=href,
                           target="_blank")
-    
+
     links <- column(2, tags$label("External links"),
                     tags$ul(class="list-inline",
                             tags$li(style="padding-top: 7px;", ensemblLink),
@@ -771,14 +770,14 @@ prepareExternalLinks <- function(info, species, assembly, grch37, gene) {
     linkTo <- function(title, href) {
         tags$a(title, icon("external-link"), target="_blank", href=href)
     }
-    
+
     url <- list()
     if (!is.null(info)) {
         gene  <- info$id
         chr   <- info$seq_region_name
         start <- as.numeric(info$start)
         end   <- as.numeric(info$end)
-        
+
         ucscPos <- sprintf("chr%s:%s-%s", chr, start, end)
         url$humanProteinAtlas <- sprintf(
             "http://www.proteinatlas.org/%s/pathology", gene)
@@ -797,7 +796,7 @@ prepareExternalLinks <- function(info, species, assembly, grch37, gene) {
         assembly, ucscPos)
     url$geneCards <- paste0(
         "http://www.genecards.org/cgi-bin/carddisp.pl?gene=", gene)
-    
+
     isHuman <- !is.null(species) && species == "human"
     links <- tagList(
         if (!is.null(species) && species != "")
@@ -829,26 +828,26 @@ plotSplicingEventHelper <- function(ASevent, data=NULL) {
 }
 
 #' @rdname appServer
-#' 
+#'
 #' @importFrom highcharter highchart %>%
 #' @importFrom shiny fixedRow safeError
 #' @importFrom methods is
 #' @importFrom shinyjs hide show runjs
 infoServer <- function(input, output, session) {
     ns <- session$ns
-    
+
     # Update species/assembly according to the ones used for loading datasets
     observe({
         species  <- getSpecies()
         assembly <- getAssemblyVersion()
         selected <- paste(species, assembly)
-        
+
         if (is.null(selected) || selected == "" || length(selected) == 0) {
             selected <- "human hg19"
         }
         updateSelectizeInput(session, "selectedSpecies", selected=selected)
     })
-    
+
     # Update gene according to selected splicing event
     observe({
         ASevent <- getASevent()
@@ -861,7 +860,7 @@ infoServer <- function(input, output, session) {
         updateSelectizeInput(session, "selectedGene", choices=getGenes(),
                              selected=gene, server=TRUE)
     })
-    
+
     output$eventDiagram <- renderUI({
         ASevent <- getASevent()
         if (!is.null(ASevent)) {
@@ -872,18 +871,18 @@ infoServer <- function(input, output, session) {
         }
         return(res)
     })
-    
+
     reactiveQueryPubMed <- reactive({
         terms <- input$articleTerms
         terms <- gsub("^gene_", "", terms)
         pubmed <- queryPubMed(terms[1], terms[-1])
         return(pubmed)
     })
-    
+
     observeEvent(input$articleTerms, {
         pubmed <- tryCatch(reactiveQueryPubMed(), error=return)
         if (is(pubmed, "error")) return(NULL)
-        
+
         articles <- pubmed[-1]
         if (length(articles) >= 1) {
             articleList <- lapply(articles, articleUI)
@@ -892,7 +891,7 @@ infoServer <- function(input, output, session) {
                                     "No articles match your search terms")
         }
         output$articleList <- renderUI(articleList)
-        
+
         search <- pubmed$search$querytranslation
         search <- gsub("[Abstract]", "[Title/Abstract]", search, fixed=TRUE)
         search <- paste0("http://www.ncbi.nlm.nih.gov/pubmed/?term=", search)
@@ -900,20 +899,20 @@ infoServer <- function(input, output, session) {
                        "Show more articles", icon("external-link"))
         output$articleSearch <- renderUI(link)
     })
-    
+
     # Update gene used in search
     observe({
         gene <- input$selectedGene
         if (gene == "") return(NULL)
         terms <- isolate(input$articleTerms)
-        
+
         genePrefix <- "gene_"
         terms <- terms[!startsWith(terms, genePrefix)]
         selected <- c(setNames(paste0(genePrefix, gene), gene), terms)
         updateSelectizeInput(session, "articleTerms", choices=selected,
                              selected=selected)
     })
-    
+
     observe({
         parsed   <- parseSpeciesAssembly(input$selectedSpecies)
         if (is.null(parsed)) return(NULL)
@@ -921,23 +920,23 @@ infoServer <- function(input, output, session) {
         assembly <- parsed$assembly
         grch37   <- assembly == "hg19"
         gene     <- input$selectedGene
-        
+
         if (gene == "") return(NULL)
-        info <- tryCatch(queryEnsemblByGene(gene, species=species, 
+        info <- tryCatch(queryEnsemblByGene(gene, species=species,
                                             assembly=assembly), error=return)
-            
+
         if (is(info, "error") || is.null(info)) {
             hide("info")
         } else {
             show("info")
         }
-        
+
         output$genetic <- renderUI({
             if (is(info, "error")) info <- NULL
             geneticInfo <- renderGeneticInfo(
                 output, info, species, assembly, grch37,
                 eventDiagram=uiOutput(ns("eventDiagram")), gene=gene)
-            
+
             if (is.null(info)) {
                 error <- errorDialog(
                     "No response from Ensembl", bigger=TRUE,
@@ -948,41 +947,41 @@ infoServer <- function(input, output, session) {
             }
             return(res)
         })
-        
+
         output$info <- renderUI({
             tagList(
-                h3("Transcripts"), 
+                h3("Transcripts"),
                 uiOutput(ns("plotTranscripts")),
                 h3("Protein domains"),
                 uiOutput(ns("selectProtein")),
                 uiOutput(ns("proteinError")),
                 highchartOutput(ns("plotProtein"), height="200px"))
         })
-        
+
         output$plotTranscripts <- renderUI({
             info <- queryEnsemblByGene(gene, species=species, assembly=assembly)
-            plotTranscripts(info, event=getASevent(), shiny=TRUE)
+            plotTranscripts(info, event=isolate(getASevent()), shiny=TRUE)
         })
-        
+
         # Show NULL so it doesn't show previous results when loading
         output$selectProtein <- renderUI("Loading...")
         output$proteinError  <- renderUI(NULL)
         output$plotProtein   <- renderHighchart(NULL)
-        
+
         output$selectProtein <- renderUI({
             transcripts <- info$Transcript$id
             tagList(
                 fixedRow(
                     column(3, selectizeInput(ns("selectedTranscript"),
-                                             label="Select a transcript", 
+                                             label="Select a transcript",
                                              choices=transcripts,
                                              width="auto")),
                     uiOutput(ns("proteinInfo"))))
         })
     })
-    
+
     plotProteinReactive <- reactive({ plotProtein(input$selectedTranscript) })
-    
+
     # Render UniProt protein domains and information
     observe({
         transcript <- input$selectedTranscript
@@ -990,7 +989,7 @@ infoServer <- function(input, output, session) {
         if (is.null(parsed)) return(NULL)
         species    <- parsed$species
         assembly   <- parsed$assembly
-        
+
         if (is.null(transcript) || transcript == "") {
             output$proteinInfo  <- renderUI(NULL)
             output$proteinError <- renderUI(NULL)
@@ -999,7 +998,7 @@ infoServer <- function(input, output, session) {
             hc <- tryCatch(plotProteinReactive(), error=return)
             output$proteinInfo  <- renderUI({
                 if (is.null(species) || is.null(assembly)) return(NULL)
-                
+
                 if (!is(hc, "error") && !is.null(hc)) {
                     protein <- attr(hc, "protein")
                     renderProteinInfo(protein, transcript, species, assembly)

--- a/R/utils_drawSplicingEvent.R
+++ b/R/utils_drawSplicingEvent.R
@@ -278,10 +278,10 @@ diagramSplicingEvent <- function(
             ifelse(isA2ref, pos_A2e, pos_A1e),
             ifelse(isA2ref, pos_A1e, pos_A2e),
             pos_C2s,
-            ifelse(isA2ref, alternative1Fill, constitutiveFill),
-            ifelse(isA2ref, alternative1Stroke, constitutiveStroke),
             ifelse(isA2ref, constitutiveFill, alternative1Fill),
-            ifelse(isA2ref, constitutiveStroke, alternative1Stroke))
+            ifelse(isA2ref, constitutiveStroke, alternative1Stroke),
+            ifelse(isA2ref, alternative1Fill, constitutiveFill),
+            ifelse(isA2ref, alternative1Stroke, constitutiveStroke))
     } else if (isALE || isA3SS) {
         pos_C1s  <- as.numeric(parsed$constitutive1)
         pos_A1e  <- as.numeric(parsed$alternative1)

--- a/dev/event_diagrams.R
+++ b/dev/event_diagrams.R
@@ -1,0 +1,78 @@
+# Test if event diagrams colour the same reference exon
+plotEventTranscripts <- function(e, species="human", assembly="hg19") {
+    info <- queryEnsemblByEvent(e, species=species, assembly=assembly)
+    plotTranscripts(info, event=e)
+}
+
+getReferenceExonFromPlotEventTranscripts <- function(events, ...,
+                                                     colour="#ffb153") {
+    getReferenceExonForOneEvent <- function(e, ...) {
+        hc    <- plotASeventRegion(highchart(), e)
+        bands <- hc$x$hc_opts$xAxis$plotBands
+
+        # Find coordinates of orange exon
+        index <- grep(colour, bands, fixed=TRUE)
+        found <- bands[[index]]
+        return(c(found$from, found$to))
+    }
+    pos <- pbapply::pblapply(events, getReferenceExonForOneEvent, ...)
+    names(pos) <- events
+    return(pos)
+}
+
+getReferenceExonFromPlotSplicingEvent <- function(..., colour="#ffb153") {
+    p <- plotSplicingEvent(...)
+    pattern <- sprintf(".*<rect.*%s.*>([0-9]*?)</text>.*", colour)
+    pos <- pbapply::pblapply(p, function(i) {
+        as.numeric(gsub(i[[1]], pattern=pattern, replacement="\\1"))
+    })
+    return(pos)
+}
+
+getReferenceExonFromEventID <- function(...) {
+    parsed <- parseSplicingEvent(..., coords=TRUE)
+    setNames(parsed$alternative1, rownames(parsed))
+}
+
+compareReferenceExons <- function(events, eventData=NULL) {
+    message("Extracting coordinates of exonic references from...")
+    message("  --> event IDs")
+    ref         <- getReferenceExonFromEventID(events, data=eventData)
+    message("  --> splicing diagrams")
+    diagrams    <- getReferenceExonFromPlotSplicingEvent(events, data=eventData)
+    message("  --> transcript plots...")
+    transcripts <- getReferenceExonFromPlotEventTranscripts(events)
+
+    comp <- function(event, ref, a, b) {
+        any(a[[event]] %in% ref[[event]]) && any(b[[event]] %in% ref[[event]])
+    }
+    res <- pbapply::pbsapply(names(ref), comp, ref, transcripts, diagrams)
+    names(res) <- names(ref)
+    return(res)
+}
+
+compareReferenceExonsInData <- function(data, assembly="hg19") {
+    junctionQuant <- data[[1]]$`Junction quantification`
+    annot <- loadAnnotation(listSplicingAnnotations(assembly=assembly)[[1]])
+    psi <- quantifySplicing(annot, junctionQuant)
+    events <- rownames(psi)
+    cmp <- compareReferenceExons(events, attr(psi, "rowData"))
+    return(cmp)
+}
+
+res  <- list()
+res$TCGA$data <- loadTCGAdata(cohort="BRCA")
+res$TCGA$cmp  <- compareReferenceExonsInData(res$TCGA$data, "hg19")
+print(length(res$TCGA$cmp))
+print(all(res$TCGA$cmp))
+
+res$SRA$data <- loadSRAproject("SRP053101")
+res$SRA$cmp  <- compareReferenceExonsInData(res$SRA$data, "hg38")
+print(length(res$SRA$cmp))
+print(all(res$SRA$cmp))
+
+options(timeout=1000)
+res$GTEx$data <- loadGtexData(tissue="Adipose Tissue")
+res$GTEx$cmp  <- compareReferenceExonsInData(res$GTEx$data, "hg38")
+print(length(res$GTEx$cmp))
+print(all(res$GTEx$cmp))

--- a/man/queryEnsemblByGene.Rd
+++ b/man/queryEnsemblByGene.Rd
@@ -12,10 +12,10 @@ queryEnsemblByEvent(event, species = NULL, assembly = NULL, data = NULL)
 \arguments{
 \item{gene}{Character: gene}
 
-\item{species}{Character: species (may be \code{NULL} for an Ensembl 
+\item{species}{Character: species (may be \code{NULL} for an Ensembl
 identifier)}
 
-\item{assembly}{Character: assembly version (may be NULL for an Ensembl 
+\item{assembly}{Character: assembly version (may be NULL for an Ensembl
 identifier)}
 
 \item{event}{Character: alternative splicing event}

--- a/tests/testthat/testPlotSplicingEvent.R
+++ b/tests/testthat/testPlotSplicingEvent.R
@@ -1,10 +1,5 @@
 context("Diagram alternative splicing event")
 
-plotEventTranscripts <- function(e, species="human", assembly="hg19") {
-    info <- queryEnsemblByEvent(e, species=species, assembly=assembly)
-    plotTranscripts(info, event=e)
-}
-
 test_that("Plot alternative splicing events", {
     events <- c(
         "A3SS_15_+_63353138_63353912_63353397_TPM1",

--- a/tests/testthat/testPlotSplicingEvent.R
+++ b/tests/testthat/testPlotSplicingEvent.R
@@ -1,6 +1,11 @@
 context("Diagram alternative splicing event")
 
-test_that("", {
+plotEventTranscripts <- function(e, species="human", assembly="hg19") {
+    info <- queryEnsemblByEvent(e, species=species, assembly=assembly)
+    plotTranscripts(info, event=e)
+}
+
+test_that("Plot alternative splicing events", {
     events <- c(
         "A3SS_15_+_63353138_63353912_63353397_TPM1",
         "A3SS_11_-_61118463_61117115_61117894_CYB561A3",
@@ -11,10 +16,10 @@ test_that("", {
         "ALE_12_+_56554104_56554410_56555171_MYL6",
         "ALE_8_-_38314874_38287466_38285953_FGFR1",
         "SE_9_+_6486925_6492303_6492401_6493826_UHRF2",
-        "SE_19_-_5218431_5216778_5216731_5215606_PTPRS",
+        "SE_19_-_5218431_5218431_5219478_5215606_PTPRS",
         "MXE_15_+_63335142_63335905_63336030_63336226_63336351_63349184_TPM1",
         "MXE_17_-_74090495_74087316_74087224_74086478_74086410_74085401_EXOC7")
-    
+
     diagrams <- plotSplicingEvent(events)
     expect_is(diagrams, "list")
     expect_is(diagrams, "splicingEventPlotList")
@@ -22,7 +27,7 @@ test_that("", {
         expect_is(each, "splicingEventPlot")
         expect_is(each, "character")
     }
-    
+
     # Event identifiers based on a different exon reference
     events <- c(
         "A3SS_15_+_63353138_63353397_63353912_TPM1",
@@ -35,7 +40,7 @@ test_that("", {
         "ALE_8_-_38314874_38285953_38287466_FGFR1",
         "MXE_15_+_63335142_63336226_63336351_63335905_63336030_63349184_TPM1",
         "MXE_17_-_74090495_74086478_74086410_74087316_74087224_74085401_EXOC7")
-    
+
     diagrams <- plotSplicingEvent(events)
     expect_is(diagrams, "list")
     expect_is(diagrams, "splicingEventPlotList")


### PR DESCRIPTION
* Diagrams of alternative splicing events:
    - Fix wrong coloring of reference exon used for AFE and A5SS events
* Transcript plot:
    - Avoid alternative regions from overlapping
    - Fix loading twice when selecting a new event (visual interface)